### PR TITLE
Dataconstructors

### DIFF
--- a/tests/src/Main.purs
+++ b/tests/src/Main.purs
@@ -2,65 +2,29 @@ module Main where
 
 -- import Prelude
 
--- int1 :: Int
--- int1 = 5
+int1 :: Int
+int1 = 5
 
--- int2 :: Int
--- int2 = int1
+int2 :: Int
+int2 = int1
 
--- string1 :: String
--- string1 = "Hello World!"
+string1 :: String
+string1 = "Hello World!"
 
--- char1 :: Char
--- char1 = 'C'
+char1 :: Char
+char1 = 'C'
 
--- array1 :: Array Int
--- array1 = [1, 2, 3, 4]
+array1 :: Array Int
+array1 = [1, 2, 3, 4]
 
--- fun1 :: Int -> Int
--- fun1 arg = arg
+fun1 :: Int -> Int
+fun1 arg = arg
 
--- rec1 :: { x :: Int, y :: String, z :: Int -> Int }
--- rec1 = { x: 1, y: "Hello", z: \x -> x }
+rec1 :: { x :: Int, y :: String, z :: Int -> Int }
+rec1 = { x: 1, y: "Hello", z: \x -> x }
 
--- newtype Foo = Foo Int
+newtype Foo = Foo Int
 
-data B = B Int Int
+data B = A | B Int Int Int
 
--- data Bar = A Int | B Int String | C
-
--- barApp1 :: Bar
--- barApp1 = A 10
-
--- barApp2 :: Bar
--- barApp2 = B 3 "Hello"
-
--- barApp3 :: Bar
--- barApp3 = C
-
--- data Foo = Foo Int
-
--- data Unit = Unit
-
-
--- _string :: String
--- _string = "Hello World!"
-
--- _char :: Char
--- _char = 'a'
-
--- _array :: Array Int
--- _array = [1, 2, 3, 4]
-
--- _record :: { x :: Int, y :: String }
--- _record = { x: 1, y: "Hello" }
-
--- _fun :: Int -> Int
--- _fun arg = arg + arg
-
-
--- func :: Int -> Int
--- func arg = arg + 2
-
--- func3 :: Int -> Int -> Int
--- func3 arg arg2 = arg + arg2
+-- b1 = B 1 2 3


### PR DESCRIPTION
I'm merging this right now even if it's not 100% working, as I've made a lot of changes that could potentially bring a lot of conflicts.

I've made some questionable choices but, without knowing how some things are going to be used at later stages of the code generation, I think it's better to wait before spending too much time perfecting things.
I still haven't got to data constructor application.
There's an issue with semicolons, I will open an issue for it.

Having 
```purescript
data B = A | B Int Int Int
```

This is the result:
```php
class A {
    public function __construct() {

    };
    var $value = new self();
};
class B {
    var $value0;
    var $value1;
    var $value2;
    public function __construct($value0, $value1, $value2) {
        $this->value0 = $value0;
        $this->value1 = $value1;
        $this->value2 = $value2;
    };
    public static function create($value0) {
        return fn($value1) => 
            fn($value2) => 
                new self($value0, $value1, $value2);;;
    };
};
```